### PR TITLE
fix error caused by missing content type in html() method (fix #276, #396)

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -619,6 +619,9 @@ const s3ContentTypes = {
   'application/pdf': {
     extension: 'pdf',
   },
+  'text/html': {
+    extension: 'html',
+  },
 }
 
 export async function uploadToS3(

--- a/src/util.ts
+++ b/src/util.ts
@@ -640,7 +640,7 @@ export async function uploadToS3(
       Key: s3Path,
       ContentType: contentType,
       ACL: getS3FilesPermissions(),
-      Body: Buffer.from(data, 'base64'),
+      Body: Buffer.from(data, contentType === 'text/html' ? 'utf8' : 'base64'),
     })
     .promise()
 


### PR DESCRIPTION
bugfix for html() method running as proxy